### PR TITLE
Use webContents.openDevTools instead of mainWindow.openDevTools

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ app.on('ready', function() {
   mainWindow.loadUrl('file://' + __dirname + '/index.html');
 
   // Open the devtools.
-  mainWindow.openDevTools();
+  mainWindow.webContents.openDevTools();
 
   // Emitted when the window is closed.
   mainWindow.on('closed', function() {


### PR DESCRIPTION
`mainWindow.openDevTools` is a deprecated API as mentioned here: https://github.com/atom/electron/issues/3125#issuecomment-148975593

And the app is still working.

![image](https://cloud.githubusercontent.com/assets/2864371/10614358/7c57a0fc-7762-11e5-9a0b-56b1b3e28f9e.png)

@ngoldman Btw, thanks for this nice app! :smile: 
